### PR TITLE
fix(library): migrate publishToMavenCentral to Central Portal API

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -57,7 +56,7 @@ android {
 }
 
 mavenPublishing {
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral()
 
     signAllPublications()
 


### PR DESCRIPTION
## Summary
`vanniktech-mavenpublish` 0.36.0 (merged in #35) removed the `SonatypeHost` parameter from `publishToMavenCentral`. The build was failing with:

\`\`\`
Unresolved reference: SonatypeHost
\`\`\`

Since this project already targeted Central Portal, the migration is simply dropping the argument and the now-unused import per the plugin's deprecation note.

## Test plan
- [x] \`./gradlew :library:jvmTest\` — compiles and runs (pre-existing 不正urlとタイトル failure is addressed separately in #44)

🤖 Generated with [Claude Code](https://claude.com/claude-code)