### PR TITLE
feat(build): migrate to AGP 9 with KMP Android library plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    alias(libs.plugins.androidLibrary) apply false
+    alias(libs.plugins.androidKotlinMultiplatformLibrary) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
     alias(libs.plugins.vanniktech.mavenPublish) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.13.2"
+agp = "9.1.1"
 kotlin = "2.2.0"
 android-minSdk = "24"
 android-compileSdk = "34"
@@ -8,6 +8,6 @@ android-compileSdk = "34"
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 
 [plugins]
-androidLibrary = { id = "com.android.library", version.ref = "agp" }
+androidKotlinMultiplatformLibrary = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.36.0" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.androidKotlinMultiplatformLibrary)
     alias(libs.plugins.vanniktech.mavenPublish)
 }
 
@@ -13,8 +13,10 @@ version = "1.1.0-SNAPSHOT"
 
 kotlin {
     jvm()
-    androidTarget {
-        publishLibraryVariants("release")
+    androidLibrary {
+        namespace = "dev.usbharu.markdown"
+        compileSdk = libs.versions.android.compileSdk.get().toInt()
+        minSdk = libs.versions.android.minSdk.get().toInt()
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_1_8)
@@ -46,14 +48,6 @@ kotlin {
                 implementation(libs.kotlin.test)
             }
         }
-    }
-}
-
-android {
-    namespace = "dev.usbharu.markdown"
-    compileSdk = libs.versions.android.compileSdk.get().toInt()
-    defaultConfig {
-        minSdk = libs.versions.android.minSdk.get().toInt()
     }
 }
 


### PR DESCRIPTION
## Summary
AGP 9 では KMP プロジェクトに `com.android.library` を適用できなくなったため、新しい KMP 対応プラグイン `com.android.kotlin.multiplatform.library` へ移行しつつ AGP を 9.1.1 に上げました。

- `libs.versions.toml`: agp 8.13.2 → 9.1.1、plugin id 差し替え
- `build.gradle.kts` / `library/build.gradle.kts`: `androidLibrary` エイリアス更新
- `library/build.gradle.kts`: トップレベル `android { }` ブロックを廃止し、`kotlin { androidLibrary { namespace, compileSdk, minSdk, compilerOptions } }` に集約

#42 を置き換えるPRです (差分が bump + migration で衝突するため、こちらをマージすると #42 は自動的に閉じます)。

## Test plan
- [x] \`./gradlew :library:jvmTest\` — pass
- [x] \`./gradlew :library:macosArm64Test\` — pass
- [x] \`./gradlew :library:assembleAndroidMain\` — Android AAR が生成される
- [x] \`./gradlew :library:publishToMavenLocal --dry-run\` — 全ターゲット (jvm, android, ios*, macos*, linuxX64, mingwX64, js) の publish タスクが task graph に乗る

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)