### PR TITLE
feat(build): upgrade to Kotlin 2.3.20 and address new deprecations

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "9.1.1"
-kotlin = "2.2.0"
+kotlin = "2.3.20"
 android-minSdk = "24"
 android-compileSdk = "34"
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -13,7 +13,7 @@ version = "1.1.0-SNAPSHOT"
 
 kotlin {
     jvm()
-    androidLibrary {
+    android {
         namespace = "dev.usbharu.markdown"
         compileSdk = libs.versions.android.compileSdk.get().toInt()
         minSdk = libs.versions.android.minSdk.get().toInt()
@@ -26,7 +26,6 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
     macosArm64()
-    macosX64()
     linuxX64()
     mingwX64()
     @OptIn(ExperimentalWasmDsl::class)


### PR DESCRIPTION
## Summary
Kotlin 2.3.20 への上げと、それに伴う DSL 変更/target 整理。

- \`kotlin\` バージョン: 2.2.0 → 2.3.20
- KMP Android DSL の rename: \`kotlin { androidLibrary { } }\` → \`kotlin { android { } }\` (Kotlin 2.3 で \`androidLibrary\` ブロックが非推奨化)
- \`macosX64()\` を削除 — Kotlin 2.3 で native target tier から外れて deprecated になったため (参考: https://kotl.in/native-targets-tiers)。macosArm64 のみ残します

#38 を置き換えるPRです。

## Test plan
- [x] \`./gradlew :library:jvmTest\` — pass
- [x] \`./gradlew :library:macosArm64Test\` — pass
- [x] \`./gradlew :library:assembleAndroidMain\` — Android AAR が生成される
- [x] 旧 deprecation 2件 (\`androidLibrary\` / \`macosX64\`) が warning output から消えたことを確認済み

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)